### PR TITLE
Place filters in activities card

### DIFF
--- a/src/pages/EvaluationsPage.tsx
+++ b/src/pages/EvaluationsPage.tsx
@@ -204,32 +204,6 @@ const EvaluationsPage = () => {
               ))}
             </SelectContent>
           </Select>
-          <Select value={classFilter} onValueChange={setClassFilter}>
-            <SelectTrigger className="w-40">
-              <SelectValue placeholder="Filtrar turma" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todas</SelectItem>
-              {classes.map((cls) => (
-                <SelectItem key={cls.id} value={cls.name}>
-                  {cls.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={subjectFilter} onValueChange={setSubjectFilter}>
-            <SelectTrigger className="w-40">
-              <SelectValue placeholder="Filtrar disciplina" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todas</SelectItem>
-              {subjects.map((subject) => (
-                <SelectItem key={subject} value={subject}>
-                  {subject}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
         </div>
       </header>
 
@@ -244,8 +218,36 @@ const EvaluationsPage = () => {
           {/* Activities List Tab */}
           <TabsContent value="activities" className="space-y-6">
             <Card className="border-0 shadow-sm">
-              <CardHeader>
+              <CardHeader className="flex flex-row items-center justify-between">
                 <CardTitle>Atividades e Avaliações</CardTitle>
+                <div className="flex items-center space-x-4">
+                  <Select value={classFilter} onValueChange={setClassFilter}>
+                    <SelectTrigger className="w-40">
+                      <SelectValue placeholder="Filtrar turma" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Todas</SelectItem>
+                      {classes.map((cls) => (
+                        <SelectItem key={cls.id} value={cls.name}>
+                          {cls.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select value={subjectFilter} onValueChange={setSubjectFilter}>
+                    <SelectTrigger className="w-40">
+                      <SelectValue placeholder="Filtrar disciplina" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Todas</SelectItem>
+                      {subjects.map((subject) => (
+                        <SelectItem key={subject} value={subject}>
+                          {subject}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
               </CardHeader>
               <CardContent>
                 <Table>


### PR DESCRIPTION
## Summary
- move class/subject filters from header into "Atividades e Avaliações" card
- align filters to right of the card title

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871c7893610832d898fdfbd522cd015